### PR TITLE
The "Social Media Health Insights" card now displays a Dubai map heat…

### DIFF
--- a/healthpulse/public/social_media.csv
+++ b/healthpulse/public/social_media.csv
@@ -9,3 +9,6 @@ SM000007,2023-01-19,Palm Jumeirah,My kid has a fever and pulling at his ear,-0.6
 SM000008,2023-01-21,Al Qusais,Stomach pain after every meal,-0.5
 SM000009,2023-01-24,Mirdif,Knees hurting when climbing stairs,-0.4
 SM000010,2023-01-27,Dubai Marina,Sore throat and can't swallow,-0.8
+SM000011,2023-01-27,Deira,"Had stomach bug",-0.8
+SM000012,2023-01-27,Deira,"My leg is swollen",-0.7
+SM000013,2023-01-27,Deira,"I have a headache and my neck is stiff",-0.6

--- a/healthpulse/src/components/cards/SocialMediaCard.tsx
+++ b/healthpulse/src/components/cards/SocialMediaCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Modal from '../Modal';
 import { loadCSV } from '../../utils/csvLoader';
+import SocialMediaHeatmap from './SocialMediaHeatmap';
 
 const CSV_URL = '/social_media.csv';
 
@@ -8,6 +9,7 @@ const SocialMediaCard: React.FC<{ timeRange: string; district: string }> = ({ ti
   const [socialData, setSocialData] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
+  const [selectedDistrict, setSelectedDistrict] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -19,13 +21,24 @@ const SocialMediaCard: React.FC<{ timeRange: string; district: string }> = ({ ti
       .catch(() => setLoading(false));
   }, []);
 
-  // Optionally, filter by district and timeRange here
+  // Filter by dashboard district (if set)
   const filtered = socialData.filter(item =>
     (!district || district === 'All' || item.district?.includes(district))
   );
 
+  // Count mentions per district for heatmap
+  const districtCounts = filtered.reduce((acc: Record<string, number>, item: any) => {
+    acc[item.district] = (acc[item.district] || 0) + 1;
+    return acc;
+  }, {});
+
+  // Posts for selected district
+  const postsForDistrict = selectedDistrict
+    ? filtered.filter(item => item.district === selectedDistrict)
+    : [];
+
   return (
-    <div className="dashboard-card" tabIndex={0} role="button" onClick={() => setModalOpen(true)}>
+    <div className="dashboard-card" tabIndex={0}>
       <div className="card-header">
         <h2 className="card-title">Social Media Health Insights</h2>
         <div className="insight-tag">Early Signals</div>
@@ -34,48 +47,42 @@ const SocialMediaCard: React.FC<{ timeRange: string; district: string }> = ({ ti
         {loading ? (
           <div>Loading...</div>
         ) : (
-          <ul style={{maxHeight: 180, overflowY: 'auto', padding: 0, margin: 0}}>
-            {filtered.slice(0, 8).map((item, idx) => (
-              <li key={idx} style={{marginBottom: 8, listStyle: 'none'}}>
-                <strong>{item.district}:</strong> <span>{item.symptoms_mentioned}</span>
-                <span style={{color: item.sentiment_score < 0 ? '#dc3545' : '#28a745', marginLeft: 8}}>
-                  ({item.sentiment_score})
-                </span>
-              </li>
-            ))}
-          </ul>
+          <SocialMediaHeatmap
+            districtCounts={districtCounts}
+            onDistrictClick={district => {
+              if (districtCounts[district] > 0) {
+                setSelectedDistrict(district);
+                setModalOpen(true);
+              }
+            }}
+          />
         )}
       </div>
       <div className="card-footer">
-        <span>Increasing mentions of respiratory symptoms detected</span>
+        <span>Click a region to view recent posts</span>
         <div className="alert-tag">Emerging Pattern</div>
       </div>
       <Modal open={modalOpen} onClose={() => setModalOpen(false)}>
         <button aria-label="Close" onClick={() => setModalOpen(false)} style={{ position: 'absolute', top: 12, right: 12, fontSize: 18, background: 'none', border: 'none', cursor: 'pointer', zIndex: 2 }}>&times;</button>
-        <h2>Social Media Mentions</h2>
+        <h2 style={{marginTop:0, fontSize:'1.2rem', fontWeight:600, textAlign:'center'}}>
+          {selectedDistrict ? `Recent Posts from ${selectedDistrict}` : 'Recent Posts'}
+        </h2>
         {loading ? (
           <div>Loading...</div>
+        ) : postsForDistrict.length === 0 ? (
+          <div style={{textAlign:'center', color:'#888', margin:32}}>No recent posts for this region.</div>
         ) : (
-          <table className="inventory-table">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>District</th>
-                <th>Symptoms Mentioned</th>
-                <th>Sentiment</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.slice(0, 50).map((item, idx) => (
-                <tr key={idx}>
-                  <td>{item.post_date}</td>
-                  <td>{item.district}</td>
-                  <td>{item.symptoms_mentioned}</td>
-                  <td>{item.sentiment_score}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <ul style={{maxHeight: 340, overflowY: 'auto', padding: 0, margin: 0}}>
+            {postsForDistrict.slice(0, 10).map((item, idx) => (
+              <li key={idx} style={{marginBottom: 16, listStyle: 'none', borderBottom: '1px solid #eee', paddingBottom: 8}}>
+                <div style={{fontWeight:600, color:'#2791D3'}}>{item.post_date}</div>
+                <div style={{margin:'4px 0'}}>{item.symptoms_mentioned}</div>
+                <div style={{color: item.sentiment_score < 0 ? '#dc3545' : '#28a745'}}>
+                  Sentiment: {item.sentiment_score}
+                </div>
+              </li>
+            ))}
+          </ul>
         )}
       </Modal>
     </div>

--- a/healthpulse/src/components/cards/SocialMediaHeatmap.tsx
+++ b/healthpulse/src/components/cards/SocialMediaHeatmap.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+
+interface SocialMediaHeatmapProps {
+  districtCounts: Record<string, number>;
+  onDistrictClick: (district: string) => void;
+}
+
+const DUBAI_DISTRICTS = [
+  'Dubai Marina',
+  'Jumeirah',
+  'Deira',
+  'Al Barsha',
+  'Bur Dubai',
+  'Business Bay',
+  'Downtown Dubai',
+  'Palm Jumeirah',
+  'Al Qusais',
+  'Mirdif',
+];
+
+// Adjusted coordinates for a 100% width x 200px height map
+const DISTRICT_COORDS: Record<string, { left: string; top: string }> = {
+  'Dubai Marina': { left: '23%', top: '58%' },
+  'Jumeirah': { left: '28%', top: '45%' },
+  'Deira': { left: '35%', top: '28%' },
+  'Al Barsha': { left: '33%', top: '86%' },
+  'Bur Dubai': { left: '54%', top: '58%' },
+  'Business Bay': { left: '34%', top: '48%' },
+  'Downtown Dubai': { left: '40%', top: '52%' },
+  'Palm Jumeirah': { left: '20%', top: '50%' },
+  'Al Qusais': { left: '37%', top: '20%' },
+  'Mirdif': { left: '42%', top: '20%' },
+};
+
+const getHeatColor = (count: number) => {
+  if (count >= 7) return 'rgba(255, 69, 0, 0.85)'; // red
+  if (count >= 4) return 'rgba(255, 140, 0, 0.75)'; // orange
+  if (count >= 2) return 'rgba(255, 215, 0, 0.65)'; // yellow
+  if (count === 1) return 'rgba(39,145,211,0.5)'; // blue
+  return 'rgba(180,180,180,0.15)'; // faint/gray
+};
+
+const SocialMediaHeatmap: React.FC<SocialMediaHeatmapProps> = ({ districtCounts, onDistrictClick }) => {
+  // Make the container as tall as the image's natural height (auto height)
+  return (
+    <div style={{ position: 'relative', width: '100%', height: 300, background: '#f5f5f5', borderRadius: 12, overflow: 'hidden', marginBottom: 8 }}>
+      <img
+        src={"/dubai_map_placeholder.png"}
+        alt="Dubai Map"
+        style={{ width: '100%', height: '100%', display: 'block', objectFit: 'contain', opacity: 0.95 }}
+      />
+      {DUBAI_DISTRICTS.map((district) => {
+        const count = districtCounts[district] || 0;
+        const coords = DISTRICT_COORDS[district];
+        if (!coords) return null;
+        return (
+          <div
+            key={district}
+            title={`${district}: ${count} mentions`}
+            onClick={() => count > 0 && onDistrictClick(district)}
+            style={{
+              position: 'absolute',
+              left: coords.left,
+              top: coords.top,
+              transform: 'translate(-50%, -50%)',
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              background: getHeatColor(count),
+              border: count > 0 ? '2px solid #fff' : 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: count >= 4 ? '#fff' : '#333',
+              fontWeight: 700,
+              fontSize: 14,
+              cursor: count > 0 ? 'pointer' : 'default',
+              boxShadow: count > 0 ? '0 0 12px 4px rgba(255,69,0,0.18)' : undefined,
+              opacity: count > 0 ? 1 : 0.6,
+              transition: 'background 0.2s',
+              zIndex: 2,
+            }}
+          >
+            {count > 0 ? count : ''}
+          </div>
+        );
+      })}
+      {/* Legend */}
+      <div style={{position:'absolute',right:8,bottom:8,background:'rgba(255,255,255,0.85)',borderRadius:6,padding:'4px 10px',fontSize:12,color:'#333',zIndex:3}}>
+        <span style={{marginRight:8}}><span style={{display:'inline-block',width:12,height:12,background:'rgba(255,69,0,0.85)',borderRadius:3,marginRight:2}}></span>7+</span>
+        <span style={{marginRight:8}}><span style={{display:'inline-block',width:12,height:12,background:'rgba(255,140,0,0.75)',borderRadius:3,marginRight:2}}></span>4-6</span>
+        <span style={{marginRight:8}}><span style={{display:'inline-block',width:12,height:12,background:'rgba(255,215,0,0.65)',borderRadius:3,marginRight:2}}></span>2-3</span>
+        <span><span style={{display:'inline-block',width:12,height:12,background:'rgba(39,145,211,0.5)',borderRadius:3,marginRight:2}}></span>1</span>
+      </div>
+    </div>
+  );
+};
+
+export default SocialMediaHeatmap;


### PR DESCRIPTION
…map, with clickable regions representing each district.

The "Social Media Health Insights" card now displays a Dubai map heatmap, with clickable regions representing each district. When you click on a district with social media mentions, a modal pops up showing the most recent posts from that area, including date, symptoms, and sentiment.

What’s improved:

Visual heatmap overlay on your Dubai map (/public/dubai_map_placeholder.png). Clickable districts with color intensity based on mention count. Modal with recent posts for the selected district, styled for clarity and quick reading.